### PR TITLE
Add various metrics and allow configuration via environment variables

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -193,7 +193,7 @@ class Exporter(object):
         if device.humidity:
             self.metric_humidity_actual.labels(room=room, device_label=device.label).set(device.humidity)
         logging.info(
-            "room: {}, label: {}, temperature_actual: {}, temperature_setpoint: {}, humidity_actual: {}"
+            "found device: room: {}, label: {}, temperature_actual: {}, temperature_setpoint: {}, humidity_actual: {}"
             .format(room, device.label, device.actualTemperature, device.setPointTemperature, device.humidity)
         )
 
@@ -207,7 +207,7 @@ class Exporter(object):
         self.metric_valve_position.labels(room=room, device_label=device.label).set(device.valvePosition)
 
         logging.info(
-            "room: {}, label: {}, temperature_actual: {}, temperature_setpoint: {}, valve_adaption_needed: {}, "
+            "found device: room: {}, label: {}, temperature_actual: {}, temperature_setpoint: {}, valve_adaption_needed: {}, "
             "temperature_offset {}, valve_position: {}"
                 .format(room, device.label, device.valveActualTemperature, device.setPointTemperature,
                         device.automaticValveAdaptionNeeded, device.temperatureOffset, device.valvePosition)
@@ -235,19 +235,24 @@ class Exporter(object):
             ).set(device.lastStatusUpdate.timestamp())
 
     def __collect_switch_metrics(self, room, device):
+        logging.info(
+            "found device: room: {}, label: {}, switch_status: {}"
+                .format(room, device.label, device.on)
+        )        
         self.metric_switch_on.labels(room=room,device_label=device.label).set(device.on)
 
     def __collect_window_state(self, room, device):
+        logging.info(
+            "found device: room: {}, label: {}, window_state: {}"
+                .format(room, device.label, device.windowState)
+        )        
         self.metric_window_state.labels(room=room,device_label=device.label).state(device.windowState)
 
     def __collect_power_metrics(self, room, device):
         logging.info(
-            "found device: room: {}, label: {}, device_type: {}, firmware_version: {}, last_status_update: {}, permanently_reachable: {}"
-                .format(room, device.label, device.deviceType.lower(), device.firmwareVersion, device.lastStatusUpdate,
-                        device.permanentlyReachable)
+            "found device: room: {}, label: {}, power_consumption: {}, energy_counter: {}"
+                .format(room, device.label, device.currentPowerConsumption, device.energyCounter)
         )
-        # general device info metric
-        logging.info(device.currentPowerConsumption)
         self.metric_power_consumption.labels(room=room,device_label=device.label).set(device.currentPowerConsumption),
         self.metric_energy_counter.labels(room=room,device_label=device.label).set(device.energyCounter)
 

--- a/exporter.py
+++ b/exporter.py
@@ -3,6 +3,7 @@ import sys
 import time
 import logging
 import homematicip
+import configargparse
 import prometheus_client
 from homematicip.home import Home, EventType
 from homematicip.device import WallMountedThermostatPro, TemperatureHumiditySensorWithoutDisplay, \
@@ -332,29 +333,39 @@ class Exporter(object):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
+    parser = configargparse.ArgumentParser(
         description='HomematicIP Prometheus Exporter',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument('--metric-port',
+                        type=int,
+                        env_var='METRIC_PORT',
                         default=8000,
                         help='port to expose the metrics on')
     parser.add_argument('--config-file',
+                        env_var='CONFIG_FILE',
                         default='/etc/homematicip-rest-api/config.ini',
                         help='path to the configuration file')
     parser.add_argument('--collect-interval-seconds',
+                        type=int,
+                        env_var='COLLECT_INTERVAL_SECONDS',
                         default=30,
                         help='collection interval in seconds')
     parser.add_argument('--auth-token',
+                        env_var='AUTH_TOKEN',
                         default=None,
                         help='homematic IP auth token')
     parser.add_argument('--access-point',
+                        env_var='ACCESS_POINT',
                         default=None,
                         help='homematic IP access point id')
     parser.add_argument('--enable-event-metrics',
+                        env_var='ENABLE_EVENT_METRICS',
                         default=False,
                         help='collect event metrics')
     parser.add_argument('--log-level',
+                        type=int,
+                        env_var='LOG_LEVEL',
                         default=30,
                         help='log level')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-homematicip ~= 0.11.0
-prometheus_client >= 0.8.0
+homematicip ~= 0.13.0
+prometheus_client >= 0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 homematicip ~= 0.13.0
 prometheus_client >= 0.9.0
+configargparse


### PR DESCRIPTION
This will add the following metrics:
- energy counter of measuring switches
- dim level of dimmers
- power status of switches
- window states for contact devices

This also changes the instance comparison to use superclass to detect more devices

Besides that, the argument parsing is switched to use [ConfigArgParse](https://pypi.org/project/ConfigArgParse/), which allows to use environment variables for configuration

Since this is the first time ever writing some Python code and also contributing on Github, please let me know if there is room for improvement 😄 

