### PR TITLE
Fix object mismatch in timeout

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -276,7 +276,7 @@ class Exporter(object):
             )
         finally:
             logging.info('waiting {}s before next collection cycle'.format(self.__collect_interval_seconds))
-            time.sleep(self.__collect_interval_seconds)
+            time.sleep(int(self.__collect_interval_seconds))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The time.sleep function needs a int object to work.
This PR is fixing this whith a ```time.sleep(int(123))```